### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().and()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/devopscope/ghas-bootcamp-jotb2025/security/code-scanning/5](https://github.com/devopscope/ghas-bootcamp-jotb2025/security/code-scanning/5)

To fix the issue, CSRF protection should be re-enabled unless there is a strong justification for disabling it. If the application is accessed by browser clients, CSRF protection is essential. If the application is strictly used by non-browser clients, the code should include a clear comment explaining why CSRF protection is disabled and ensure that other safeguards are in place.

The best way to fix the problem is to remove the `http.csrf().disable()` line and allow Spring Security's default CSRF protection to remain enabled. If specific endpoints need to bypass CSRF protection, they can be explicitly configured using `csrf().ignoringAntMatchers()`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
